### PR TITLE
add Qdrant setup with Docker Compose and test connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# Qdrant local storage
+qdrant_storage/

--- a/backend/test_qdrant_connection.py
+++ b/backend/test_qdrant_connection.py
@@ -1,0 +1,66 @@
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams, PointStruct
+import numpy as np
+
+def test_qdrant_connection():
+    """Test local Qdrant connection"""
+    try:
+        # connect to Qdrant
+        client = QdrantClient(host="localhost", port=6333)
+        
+        print("Successfully connected to Qdrant")
+        
+        # get collections
+        collections = client.get_collections()
+        print(f"Existing collections: {len(collections.collections)}")
+        
+        # create test collection
+        test_collection = "connection_test"
+        
+        # clean up if exists
+        try:
+            client.delete_collection(test_collection)
+        except:
+            pass
+        
+        # create collection
+        client.create_collection(
+            collection_name=test_collection,
+            vectors_config=VectorParams(size=384, distance=Distance.COSINE)
+        )
+        print(f"Created test collection: {test_collection}")
+        
+        # insert test vector
+        client.upsert(
+            collection_name=test_collection,
+            points=[
+                PointStruct(
+                    id=1,
+                    vector=np.random.rand(384).tolist(),
+                    payload={"test": "data", "team": "lighthouse"}
+                )
+            ]
+        )
+        print("Inserted test vector")
+        
+        # search test
+        results = client.search(
+            collection_name=test_collection,
+            query_vector=np.random.rand(384).tolist(),
+            limit=1
+        )
+        print(f"Search successful! Found {len(results)} result(s)")
+        
+        # cleanup
+        client.delete_collection(test_collection)
+        print("Test complete and cleaned up")
+        print("\nQdrant is working correctly!")
+        
+        return True
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        return False
+
+if __name__ == "__main__":
+    test_qdrant_connection()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: lighthouse_qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./qdrant_storage:/qdrant/storage:z
+    restart: unless-stopped
+    environment:
+      - QDRANT__SERVICE__GRPC_PORT=6334
+
+# WILL USE THIS PART LATER
+  # backend:
+  #   build: ./backend
+  #   ports:
+  #     - "8000:8000"
+  #   depends_on:
+  #     - qdrant
+  #   environment:
+  #     - QDRANT_HOST=qdrant
+  #     - QDRANT_PORT=6333
+  
+
+  # frontend:
+  #   build: ./frontend
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
+  #     - backend


### PR DESCRIPTION
## Qdrant Local Setup Guide:

### Need to have:
- Docker Desktop installed and running (https://www.docker.com/products/docker-desktop/)
- Python 3.8+ installed

### Step 1:
- cd into repository

### Step 2:
- pwd and make sure you're in correct repo
- also run git pull to update once this PR is approved

### Step 3
- start up Qdrant by running `docker compose up -d`
- should see something like this: `[+] Running 1/1
 ✔ Container lighthouse_qdrant  Started`
- this will start Qdrant in background and expose ports; creates qdrant-storage/ for data persistence (we can get rid of this later just for testing)
- run `docker compose ps` to make sure container is running properly
- should see something like `NAME                 IMAGE                  STATUS          PORTS
lighthouse_qdrant    qdrant/qdrant:latest   Up 10 seconds   0.0.0.0:6333-6334->6333-6334/tcp`


### Step 4:
- open web browser and go to `http://localhost:6333/dashboard`
- Qdrant dashboard interface should show up
- or run `curl http://localhost:6333` in terminal to see; either way it should be clear if it worked

### Step 5:
- install `python3 -m pip install qdrant-client numpy`
- cd into `backend` and run `python3 test_qdrant_connection.py`
- should show if it is working properly

### Commands:
- start container: `docker compose up -d`
- stop container: `docker compose down`
- check status: `docker ps`
- view logs for debugging: `docker compose logs -f qdrant`


